### PR TITLE
fixing heroku memory error

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: npm run build && npm start
+web: npm start


### PR DESCRIPTION
Basically you use the Procfile to tell Heroku how to run various pieces of your app.  Heroku will route HTTP requests to processes started with the "web" name.  This means just running your server and it responding to the request aka send the HTML page and the attached JS game code.  This should be it, as it should be compiled waaaaay before this step.  So I removed npm run build as that is done after pushing to heroku.  I believe the extra attempt to install node modules and build at this stage ate up all that memory and caused the error.